### PR TITLE
Fix inline article position in Title-Only view mode (on title click)

### DIFF
--- a/src/Externals.ts
+++ b/src/Externals.ts
@@ -47,7 +47,7 @@ var ext = {
   subscriptionChangeSelector: "#header-title",
   popularitySelector: ".EntryEngagement, .engagement, .nbrRecommendations",
   hidingInfoSibling: "header .right-col, header > h1 .button-dropdown",
-  articleUrlAnchorSelector: ".content a[href]",
+  articleUrlAnchorSelector: ".TitleOnlyEntry__content > a, .MagazineEntry__content > a, .CardEntry__content > a, .content > a[href]",
 
   keepArticlesUnreadId: "keepArticlesUnread",
   articlesToMarkAsReadId: "articlesToMarkAsRead",

--- a/src/FeedlyPage.ts
+++ b/src/FeedlyPage.ts
@@ -704,29 +704,28 @@ export class FeedlyPage {
       };
       onClickCapture(openAndMarkAsReadElement, openAndMarkAsRead);
 
-      let visualElement;
-      if (cardsView) {
-        visualElement = a.find(".visual-container");
-      } else if (magazineView) {
-        visualElement = a.find(".visual");
-      }
-      if (visualElement) {
-        onClickCapture(visualElement, (e) => {
-          if (getFFnS(ext.visualOpenAndMarkAsReadId)) {
-            openAndMarkAsRead(e);
-          }
-        });
-      }
-      if (titleView) {
-        onClickCapture(a.find(".content"), (e) => {
-          if (getFFnS(ext.titleOpenAndMarkAsReadId)) {
-            e.stopPropagation();
-            e.preventDefault();
-            const link = a.find("a[href]").attr("href");
-            window.open(link, link);
-            reader.askMarkEntryAsRead(entryId);
-          }
-        });
+      if (cardsView || magazineView) {
+        let visualElement = a.find(".EntryVisual");
+        if (visualElement.length > 0) {
+          onClickCapture(visualElement, (e) => {
+            if (getFFnS(ext.visualOpenAndMarkAsReadId)) {
+              openAndMarkAsRead(e);
+            }
+          });
+        }
+      } else if (titleView) {
+        let titleOnlyEntryContentElement = a.find(".TitleOnlyEntry__content");
+        if (titleOnlyEntryContentElement.length > 0) {
+          onClickCapture(titleOnlyEntryContentElement, (e) => {
+            if (getFFnS(ext.titleOpenAndMarkAsReadId)) {
+              e.stopPropagation();
+              e.preventDefault();
+              const link = a.find("a[href]").attr("href");
+              window.open(link, link);
+              reader.askMarkEntryAsRead(entryId);
+            }
+          });
+        }
       }
 
       onClickCapture(

--- a/src/FeedlyPage.ts
+++ b/src/FeedlyPage.ts
@@ -285,6 +285,11 @@ export class FeedlyPage {
         //     `child: ${child["id"] || child["classList"] || child["tagName"]}`,
         //   ];
         // }, "remove");
+        if (child.nodeName === "ARTICLE") {
+          // save id to show inline div in right place
+          // this -> EntryList__chunk node
+          $(this).attr("hiddenArticleId", child.id);
+        }
         return removeChild.apply(this, arguments);
       } catch (e) {
         if ($(this).hasClass(ext.articlesChunkClass)) {
@@ -302,6 +307,9 @@ export class FeedlyPage {
     function insertArticleNode(_, node: HTMLElement, parent: Node) {
       let sibling = null;
       try {
+        const id = node.nodeName === "ARTICLE"
+          ? getArticleId(node)
+          : $(parent).attr("hiddenArticleId").replace(/_main$/, "");
         const id = getArticleId(node);
         const sortedIds = getService("navigo").entries.map((e) => e.id);
         let nextIndex = sortedIds.indexOf(id) + 1;
@@ -335,6 +343,11 @@ export class FeedlyPage {
       //   ],
       //   "insert"
       // );
+      if (node.nodeName == "ARTICLE" && $(parent).attr("hiddenArticleId")) {
+        // it is implied that the article that is being shown
+        // is exactly the one that was hidden, so remove temp attr
+        $(parent).removeAttr("hiddenArticleId");
+      }
       return insertBefore.call(sibling.parentNode, node, sibling);
     }
     Node.prototype.insertBefore = function (node, siblingNode) {


### PR DESCRIPTION
In title-only mode the article element whose title was clicked is removed from the list (to show inline content) and and there is currently an error in `insertArticleNode` function (`getArticleId(node)` cant get the id of the hidden article because node is not article element as supposed but parent div).  As a workaround the hidden article id is saved in the parent div (EntryList__chunk) temporary attribute `hiddenArticleId`. Not the best solution, but it's works...

Also updated some selectors.